### PR TITLE
fix gapple cooldown register

### DIFF
--- a/src/main/java/me/dubai/lunar/Lunar.java
+++ b/src/main/java/me/dubai/lunar/Lunar.java
@@ -47,10 +47,9 @@ public class Lunar extends JavaPlugin {
 
         if (ConfigFile.getConfig().getBoolean("COOLDOWN.ENDERPEARL.ENABLE")) {
             LunarClientAPICooldown.registerCooldown(new LCCooldown("Enderpearl", enderpearl, TimeUnit.SECONDS, Material.ENDER_PEARL));
-
-            if (ConfigFile.getConfig().getBoolean("COOLDOWN.GAPPLE.ENABLE")) {
-                LunarClientAPICooldown.registerCooldown(new LCCooldown("Gapple", gapple, TimeUnit.SECONDS, Material.GOLDEN_APPLE));
-            }
+        }
+        if (ConfigFile.getConfig().getBoolean("COOLDOWN.GAPPLE.ENABLE")) {
+            LunarClientAPICooldown.registerCooldown(new LCCooldown("Gapple", gapple, TimeUnit.SECONDS, Material.GOLDEN_APPLE));
         }
     }
 }


### PR DESCRIPTION
If the enderpearl timer was disabled then the gapple timer would never be enabled.